### PR TITLE
Add dependencies for ubuntu 14.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,15 @@ run apt-get update && apt-get upgrade -y && apt-get install -y \
    language-pack-en-base \
    uuid-dev \
    git-core \
-   mysql-client-5.5
+   mysql-client-5.5 \
+   libffi-dev \
+   docker.io \
+   make
 ```
 
+```
+run pip install tox
+```
 
 Tests
 -----


### PR DESCRIPTION
`libffi-dev` is required for `cffi`.
`make` and `tox` are required to run the tests .
`docker-io` is required for the docker command.