### PR TITLE
Fix docker opensource build, pull from community pypi site

### DIFF
--- a/Dockerfile-opensource
+++ b/Dockerfile-opensource
@@ -38,11 +38,11 @@ RUN chmod +x /usr/local/bin/dumb-init
 
 # Add the service code
 WORKDIR /code
-ADD     requirements.txt /code/requirements-opensource.txt
+ADD     requirements-opensource.txt /code/requirements-opensource.txt
 ADD     setup.py /code/setup.py
 RUN     virtualenv -p pypy /code/virtualenv_run
 RUN     /code/virtualenv_run/bin/pip install \
-            -i https://pypi.yelpcorp.com/simple/ \
+            -i https://pypi.python.org/simple \
             -r /code/requirements-opensource.txt
 
 ADD     . /code

--- a/Makefile-opensource
+++ b/Makefile-opensource
@@ -20,7 +20,7 @@ clean:
 
 venv-dev:
 	virtualenv --python=python2.7 ./virtualenv_run
-	./virtualenv_run/bin/pip install -i https://pypi.yelpcorp.com/simple/  -r requirements.d/dev.txt
+	./virtualenv_run/bin/pip install -i https://pypi.python.org/simple  -r requirements.d/dev.txt
 
 install-hooks:
 	tox -e pre-commit -- install -f --install-hooks

--- a/requirements-opensource.txt
+++ b/requirements-opensource.txt
@@ -8,7 +8,7 @@ PyYAML==3.11
 SQLAlchemy==1.0.12
 boto==2.36.0
 contextdecorator==0.10.0
-data_pipeline==0.9.1
+data_pipeline==0.9.12
 dateglob==0.1
 enum34==1.0.4
 future==0.14.3


### PR DESCRIPTION
Fix docker opensource build, pull from community pypi site.

The default opensource docker build is break, since docker tried to pull from pypi.yelpcorp.com, which cannot be accessed from external, and it should pull from the community repository.